### PR TITLE
Maximum search depth

### DIFF
--- a/src/main/java/com/matthewglover/tictactoe/core/AlphaBeta.java
+++ b/src/main/java/com/matthewglover/tictactoe/core/AlphaBeta.java
@@ -21,14 +21,7 @@ public class AlphaBeta extends MiniMax {
     }
 
     @Override
-    public void execute() {
-        if (depth == maxSearchDepth) {
-            int currentScore = 0;
-            int currentMove = game.getNextMoves().get(0).getCurrentMove();
-            updateSelected(currentScore, currentMove);
-            updateAlphaBeta(currentScore);
-            return;
-        }
+    protected void calculateBestScore() {
         for (Game gameMove : game.getNextMoves()) {
             int currentScore = calculateMoveScore(gameMove);
             int currentMove = gameMove.getCurrentMove();
@@ -45,6 +38,12 @@ public class AlphaBeta extends MiniMax {
     }
 
     @Override
+    protected void setOutOfDepthScore() {
+        super.setOutOfDepthScore();
+        updateAlphaBeta(DRAW_SCORE);
+    }
+
+    @Override
     protected int calculateInterimMoveScore(Game gameMove) {
         AlphaBeta alphaBeta = new AlphaBeta(gameMove, maxSearchDepth,nextDepth(), isNextMaximising(), alpha, beta);
         alphaBeta.execute();
@@ -58,7 +57,7 @@ public class AlphaBeta extends MiniMax {
                 : currentScore < beta;
     }
 
-    private void updateAlphaBeta(int score) {
+    protected void updateAlphaBeta(int score) {
         if (isMaximising) {
             alpha = score;
         } else {

--- a/src/main/java/com/matthewglover/tictactoe/core/AlphaBeta.java
+++ b/src/main/java/com/matthewglover/tictactoe/core/AlphaBeta.java
@@ -7,20 +7,28 @@ public class AlphaBeta extends MiniMax {
     private int alpha;
     private int beta;
 
-    public static AlphaBeta run(Game game) {
-        AlphaBeta alphaBeta = new AlphaBeta(game, 0, true, MINIMUM_ALPHA, MAXIMUM_BETA);
+
+    public static AlphaBeta run(Game game, int maxSearchDepth) {
+        AlphaBeta alphaBeta = new AlphaBeta(game, maxSearchDepth, 0, true, MINIMUM_ALPHA, MAXIMUM_BETA);
         alphaBeta.execute();
         return alphaBeta;
     }
 
-    public AlphaBeta(Game game, int depth, boolean isMaximising, int alpha, int beta) {
-        super(game, depth, isMaximising);
+    public AlphaBeta(Game game, int maxSearchDepth, int depth, boolean isMaximising, int alpha, int beta) {
+        super(game, maxSearchDepth, depth, isMaximising);
         this.alpha = alpha;
         this.beta = beta;
     }
 
     @Override
     public void execute() {
+        if (depth == maxSearchDepth) {
+            int currentScore = 0;
+            int currentMove = game.getNextMoves().get(0).getCurrentMove();
+            updateSelected(currentScore, currentMove);
+            updateAlphaBeta(currentScore);
+            return;
+        }
         for (Game gameMove : game.getNextMoves()) {
             int currentScore = calculateMoveScore(gameMove);
             int currentMove = gameMove.getCurrentMove();
@@ -38,7 +46,7 @@ public class AlphaBeta extends MiniMax {
 
     @Override
     protected int calculateInterimMoveScore(Game gameMove) {
-        AlphaBeta alphaBeta = new AlphaBeta(gameMove, nextDepth(), isNextMaximising(), alpha, beta);
+        AlphaBeta alphaBeta = new AlphaBeta(gameMove, maxSearchDepth,nextDepth(), isNextMaximising(), alpha, beta);
         alphaBeta.execute();
         return alphaBeta.getScore();
     }

--- a/src/main/java/com/matthewglover/tictactoe/core/ComputerPlayer.java
+++ b/src/main/java/com/matthewglover/tictactoe/core/ComputerPlayer.java
@@ -3,12 +3,14 @@ package com.matthewglover.tictactoe.core;
 
 public class ComputerPlayer extends Player {
 
+    private static final int MAX_SEARCH_DEPTH = 6;
+
     public ComputerPlayer(PlayerSymbol playerSymbol) {
         super(playerSymbol);
     }
 
     @Override
     protected void makeMove(Game game) {
-        game.move(AlphaBeta.run(game).getMove());
+        game.move(AlphaBeta.run(game, MAX_SEARCH_DEPTH).getMove());
     }
 }

--- a/src/main/java/com/matthewglover/tictactoe/core/MiniMax.java
+++ b/src/main/java/com/matthewglover/tictactoe/core/MiniMax.java
@@ -2,19 +2,22 @@ package com.matthewglover.tictactoe.core;
 
 public abstract class MiniMax {
     private static final int DRAW_SCORE = 0;
-    private static final int WINNING_SCORE = 10;
+    private final int winningScore;
     protected final Game game;
+    protected final int maxSearchDepth;
     protected final int depth;
     protected final boolean isMaximising;
     protected int selectedScore;
     private int selectedMove;
 
-    public MiniMax(Game game, int depth, boolean isMaximising) {
-        this.isMaximising = isMaximising;
+    public MiniMax(Game game, int maxSearchDepth, int depth, boolean isMaximising) {
         this.game = game;
+        this.maxSearchDepth = maxSearchDepth;
         this.depth = depth;
+        this.isMaximising = isMaximising;
 
         selectedScore = isMaximising ? Integer.MIN_VALUE : Integer.MAX_VALUE;
+        winningScore = game.getBoard().getTotalSquares();
     }
 
     public int getMove() {
@@ -53,7 +56,7 @@ public abstract class MiniMax {
     }
 
     private int getBaseScore() {
-        return isMaximising ? WINNING_SCORE : -WINNING_SCORE;
+        return isMaximising ? winningScore : -winningScore;
     }
 
     private int getDepthOffset() {

--- a/src/main/java/com/matthewglover/tictactoe/core/MiniMax.java
+++ b/src/main/java/com/matthewglover/tictactoe/core/MiniMax.java
@@ -1,7 +1,7 @@
 package com.matthewglover.tictactoe.core;
 
 public abstract class MiniMax {
-    private static final int DRAW_SCORE = 0;
+    protected final int DRAW_SCORE = 0;
     private final int winningScore;
     protected final Game game;
     protected final int maxSearchDepth;
@@ -24,6 +24,14 @@ public abstract class MiniMax {
         return selectedMove;
     }
 
+    public void execute() {
+        if (isOutOfDepth()) {
+            setOutOfDepthScore();
+        } else {
+            calculateBestScore();
+        }
+    }
+
     protected int calculateMoveScore(Game gameMove) {
         return gameMove.isOver()
                 ? calculateFinalMoveScore(gameMove)
@@ -42,10 +50,22 @@ public abstract class MiniMax {
         return selectedScore;
     }
 
+    protected void setOutOfDepthScore() {
+        int currentScore = DRAW_SCORE;
+        int currentMove = game.getNextMoves().get(0).getCurrentMove();
+        updateSelected(currentScore, currentMove);
+    }
+
     protected void updateSelected(int score, int move) {
         selectedScore = score;
         selectedMove = move;
     }
+
+    protected abstract void calculateBestScore();
+
+    protected abstract int calculateInterimMoveScore(Game gameMove);
+
+    protected abstract boolean isBetterScore(int currentScore);
 
     private int calculateFinalMoveScore(Game gameMove) {
         if (gameMove.isWinner()) {
@@ -55,6 +75,10 @@ public abstract class MiniMax {
         }
     }
 
+    private boolean isOutOfDepth() {
+        return depth >= maxSearchDepth;
+    }
+
     private int getBaseScore() {
         return isMaximising ? winningScore : -winningScore;
     }
@@ -62,10 +86,4 @@ public abstract class MiniMax {
     private int getDepthOffset() {
         return isMaximising ? -depth : depth;
     }
-
-    public abstract void execute();
-
-    protected abstract int calculateInterimMoveScore(Game gameMove);
-
-    protected abstract boolean isBetterScore(int currentScore);
 }

--- a/src/main/java/com/matthewglover/tictactoe/core/SimpleMiniMax.java
+++ b/src/main/java/com/matthewglover/tictactoe/core/SimpleMiniMax.java
@@ -2,14 +2,14 @@ package com.matthewglover.tictactoe.core;
 
 public class SimpleMiniMax extends MiniMax {
 
-    public static SimpleMiniMax run(Game game) {
-        SimpleMiniMax miniMax = new SimpleMiniMax(game, 0, true);
+    public static SimpleMiniMax run(Game game, int maxSearchDepth) {
+        SimpleMiniMax miniMax = new SimpleMiniMax(game, maxSearchDepth, 0, true);
         miniMax.execute();
         return miniMax;
     }
 
-    public SimpleMiniMax(Game game, int depth, boolean isMaximising) {
-        super(game, depth, isMaximising);
+    public SimpleMiniMax(Game game, int maxSearchDepth, int depth, boolean isMaximising) {
+        super(game, maxSearchDepth, depth, isMaximising);
     }
 
     @Override
@@ -26,7 +26,7 @@ public class SimpleMiniMax extends MiniMax {
 
     @Override
     protected int calculateInterimMoveScore(Game gameMove) {
-        SimpleMiniMax miniMax = new SimpleMiniMax(gameMove, nextDepth(), isNextMaximising());
+        SimpleMiniMax miniMax = new SimpleMiniMax(gameMove, maxSearchDepth, nextDepth(), isNextMaximising());
         miniMax.execute();
         return miniMax.getScore();
     }

--- a/src/main/java/com/matthewglover/tictactoe/core/SimpleMiniMax.java
+++ b/src/main/java/com/matthewglover/tictactoe/core/SimpleMiniMax.java
@@ -13,7 +13,7 @@ public class SimpleMiniMax extends MiniMax {
     }
 
     @Override
-    public void execute() {
+    protected void calculateBestScore() {
         for (Game gameMove : game.getNextMoves()) {
             int currentScore = calculateMoveScore(gameMove);
             int currentMove = gameMove.getCurrentMove();

--- a/src/test/java/com/matthewglover/tictactoe/core/AlphaBetaTest.java
+++ b/src/test/java/com/matthewglover/tictactoe/core/AlphaBetaTest.java
@@ -6,6 +6,9 @@ import org.junit.Test;
 import static junit.framework.TestCase.assertEquals;
 
 public class AlphaBetaTest {
+
+    int MAX_SEARCH_DEPTH = 6;
+
     @Test
     public void selectsWinningMoveOverLosingMove() {
         // x o x
@@ -13,7 +16,7 @@ public class AlphaBetaTest {
         // 7 8 x
         Game game = new Game(3);
         GameTestHelper.runGame(game, new int[]{1, 2, 3, 5, 4, 6, 9});
-        AlphaBeta alphaBeta = AlphaBeta.run(game);
+        AlphaBeta alphaBeta = AlphaBeta.run(game, MAX_SEARCH_DEPTH);
         assertEquals(8, alphaBeta.getMove());
     }
 
@@ -24,7 +27,7 @@ public class AlphaBetaTest {
         // 7 o 9
         Game game = new Game(3);
         GameTestHelper.runGame(game, new int[]{1, 2, 3, 8});
-        AlphaBeta alphaBeta = AlphaBeta.run(game);
+        AlphaBeta alphaBeta = AlphaBeta.run(game, MAX_SEARCH_DEPTH);
         assertEquals(5, alphaBeta.getMove());
     }
 
@@ -32,7 +35,7 @@ public class AlphaBetaTest {
     public void runsBiggerGame() {
         Game game = new Game(4);
         GameTestHelper.runGame(game, new int[]{1, 5, 2, 6, 3, 7});
-        AlphaBeta alphaBeta = AlphaBeta.run(game);
+        AlphaBeta alphaBeta = AlphaBeta.run(game, MAX_SEARCH_DEPTH);
         assertEquals(4, alphaBeta.getMove());
     }
 
@@ -43,7 +46,7 @@ public class AlphaBetaTest {
         // 7 8 o
         Game game = new Game(3);
         GameTestHelper.runGame(game, new int[]{1, 2, 5, 9});
-        AlphaBeta alphaBeta = AlphaBeta.run(game);
+        AlphaBeta alphaBeta = AlphaBeta.run(game, MAX_SEARCH_DEPTH);
         assertEquals(4, alphaBeta.getMove());
     }
 
@@ -54,12 +57,12 @@ public class AlphaBetaTest {
         GameTestHelper.runGame(game, new int[]{5, 9, 6, 10, 7, 11});
 
         long abStartTime = System.nanoTime();
-        AlphaBeta alphaBeta = AlphaBeta.run(game);
+        AlphaBeta alphaBeta = AlphaBeta.run(game, MAX_SEARCH_DEPTH);
         long abEndTime = System.nanoTime();
         long abDuration = (abEndTime - abStartTime) / 1000000;
 
         long mmStartTime = System.nanoTime();
-        SimpleMiniMax miniMax = SimpleMiniMax.run(game);
+        SimpleMiniMax miniMax = SimpleMiniMax.run(game, MAX_SEARCH_DEPTH);
         long mmEndTime = System.nanoTime();
         long mmDuration = (mmEndTime - mmStartTime) / 1000000;
 

--- a/src/test/java/com/matthewglover/tictactoe/core/MiniMaxTest.java
+++ b/src/test/java/com/matthewglover/tictactoe/core/MiniMaxTest.java
@@ -5,6 +5,9 @@ import org.junit.Test;
 import static junit.framework.TestCase.assertEquals;
 
 public class MiniMaxTest {
+
+    int MAX_SEARCH_DEPTH = 6;
+
     @Test
     public void selectsWinningMoveOverLosingMove() {
         // x o x
@@ -12,7 +15,7 @@ public class MiniMaxTest {
         // 7 8 x
         Game game = new Game(3);
         GameTestHelper.runGame(game, new int[]{1, 2, 3, 5, 4, 6, 9});
-        SimpleMiniMax miniMax = SimpleMiniMax.run(game);
+        SimpleMiniMax miniMax = SimpleMiniMax.run(game, MAX_SEARCH_DEPTH);
         assertEquals(8, miniMax.getMove());
     }
 
@@ -23,7 +26,7 @@ public class MiniMaxTest {
         // 7 o 9
         Game game = new Game(3);
         GameTestHelper.runGame(game, new int[]{1, 2, 3, 8});
-        SimpleMiniMax miniMax = SimpleMiniMax.run(game);
+        SimpleMiniMax miniMax = SimpleMiniMax.run(game, MAX_SEARCH_DEPTH);
         assertEquals(5, miniMax.getMove());
     }
 
@@ -34,7 +37,7 @@ public class MiniMaxTest {
         // 7 8 o
         Game game = new Game(3);
         GameTestHelper.runGame(game, new int[]{1, 2, 5, 9});
-        SimpleMiniMax miniMax = SimpleMiniMax.run(game);
+        SimpleMiniMax miniMax = SimpleMiniMax.run(game, MAX_SEARCH_DEPTH);
         assertEquals(4, miniMax.getMove());
     }
 }


### PR DESCRIPTION
@priyapatil1 @jsuchy - This pull request:

1. Updates the AlphaBeta and SimpleMiniMax algorithms to accept a search depth, which limits the number of moves checked. 

2. Updates the winning score to the total number of squares. Previously I was using a winning score of 10, but with a 4x4 board, the maximum depth is 16, which could mean a winning score has a score below zero.